### PR TITLE
feat: refactor core/thread logic for mpibackend

### DIFF
--- a/hnn_core/tests/test_parallel_backends.py
+++ b/hnn_core/tests/test_parallel_backends.py
@@ -2,7 +2,6 @@ import os.path as op
 from os import environ
 import io
 from contextlib import redirect_stdout
-from multiprocessing import cpu_count
 from threading import Thread, Event
 from time import sleep
 from urllib.request import urlretrieve
@@ -16,7 +15,11 @@ import pytest
 import hnn_core
 from hnn_core import MPIBackend, jones_2009_model, read_params
 from hnn_core.dipole import simulate_dipole
-from hnn_core.parallel_backends import requires_mpi4py, requires_psutil
+from hnn_core.parallel_backends import (
+    requires_mpi4py,
+    requires_psutil,
+    _determine_cores_hwthreading,
+)
 from hnn_core.network_builder import NetworkBuilder
 
 
@@ -74,8 +77,6 @@ def test_gid_assignment():
 # simulation when there are failures in previous (faster) tests. When a test
 # in the sequence fails, all subsequent tests will be marked "xfailed" rather
 # than skipped.
-
-
 @pytest.mark.incremental
 class TestParallelBackends():
     dpls_reduced_mpi = None
@@ -101,6 +102,35 @@ class TestParallelBackends():
         for trial_idx in range(len(dpls_reduced_default)):
             assert_array_equal(dpls_reduced_default[trial_idx].data['agg'],
                                dpls_reduced_joblib[trial_idx].data['agg'])
+
+    @requires_mpi4py
+    @requires_psutil
+    @pytest.mark.parametrize("sensible_default", [False, True])
+    def test_detect_cores(self, sensible_default):
+        """Test that multiple cores can be detected"""
+        [detected_cores_nohw, detected_hwthreading] = \
+            _determine_cores_hwthreading(
+                enable_hwthreading=False,
+                sensible_default_cores=sensible_default)
+        assert detected_cores_nohw > 1
+        assert isinstance(detected_hwthreading, bool)
+
+        [detected_cores_yeshw, detected_hwthreading] = \
+            _determine_cores_hwthreading(
+                enable_hwthreading=True,
+                sensible_default_cores=sensible_default)
+        assert detected_cores_yeshw > 1
+        assert isinstance(detected_hwthreading, bool)
+
+        [detected_cores_maybehw, detected_hwthreading] = \
+            _determine_cores_hwthreading(
+                enable_hwthreading=None,
+                sensible_default_cores=sensible_default)
+        assert detected_cores_maybehw > 1
+        assert isinstance(detected_hwthreading, bool)
+
+        assert detected_cores_yeshw >= detected_cores_nohw
+        assert detected_cores_maybehw >= detected_cores_nohw
 
     @requires_mpi4py
     @requires_psutil
@@ -161,7 +191,9 @@ class TestParallelBackends():
 
     @requires_mpi4py
     @requires_psutil
-    def test_run_mpibackend_oversubscribed(self, run_hnn_core_fixture):
+    @pytest.mark.parametrize("hwthreading_enabled", [None, False, True])
+    def test_run_mpibackend_oversubscribed(self, run_hnn_core_fixture,
+                                           hwthreading_enabled):
         """Test running MPIBackend with oversubscribed number of procs"""
         hnn_core_root = op.dirname(hnn_core.__file__)
         params_fname = op.join(hnn_core_root, 'param', 'default.json')
@@ -173,17 +205,24 @@ class TestParallelBackends():
         net = jones_2009_model(params, add_drives_from_params=True,
                                mesh_shape=(3, 3))
 
-        # try running with more procs than cells in the network (will probably
-        # oversubscribe)
+        # Fail state: try running with more procs than cells in the network
+        # (will probably oversubscribe too)
         too_many_procs = net._n_cells + 1
-        with pytest.raises(ValueError, match='More MPI processes were '
-                           'assigned than there are cells'):
+
+        with pytest.raises(ValueError,
+                           match=('More MPI processes were '
+                                  'assigned than there are cells')):
             with MPIBackend(n_procs=too_many_procs) as backend:
                 simulate_dipole(net, tstop=40)
 
-        # force oversubscription + hyperthreading, but make sure there are
-        # always enough cells in the network
-        oversubscribed_procs = cpu_count() + 1
+        # Force oversubscription and make sure there are always enough cells in
+        # the network
+        [detected_cores, detected_hwthreading] = \
+            _determine_cores_hwthreading(
+                enable_hwthreading=hwthreading_enabled,
+                sensible_default_cores=False)
+
+        oversubscribed_procs = detected_cores + 1
         n_grid_1d = int(np.ceil(np.sqrt(oversubscribed_procs)))
         params.update({'t_evprox_1': 5,
                        't_evdist_1': 10,
@@ -191,8 +230,51 @@ class TestParallelBackends():
                        'N_trials': 2})
         net = jones_2009_model(params, add_drives_from_params=True,
                                mesh_shape=(n_grid_1d, n_grid_1d))
-        with MPIBackend(n_procs=oversubscribed_procs) as backend:
-            assert backend.n_procs == oversubscribed_procs
+
+        # Check that oversubscription turns on if needed, and provides a
+        # warning
+        with pytest.warns(UserWarning,
+                          match=("Number of requested MPI processes exceeds "
+                                 "available cores. Enabling MPI "
+                                 "oversubscription automatically.")):
+            with MPIBackend(
+                    n_procs=oversubscribed_procs,
+                    hwthreading=hwthreading_enabled) as backend:
+                assert backend.n_procs == oversubscribed_procs
+                assert "--oversubscribe" in ' '.join(backend.mpi_cmd)
+                if detected_hwthreading:
+                    assert "--use-hwthread-cpus" in ' '.join(backend.mpi_cmd)
+                simulate_dipole(net, tstop=40)
+
+        # Check that the simulation fails if oversubscribe is forced off
+        with pytest.warns(UserWarning) as record:
+            with MPIBackend(
+                    n_procs=oversubscribed_procs,
+                    hwthreading=hwthreading_enabled,
+                    oversubscribe=False,
+            ) as backend:
+                assert "--oversubscribe" not in ' '.join(backend.mpi_cmd)
+                if detected_hwthreading:
+                    assert "--use-hwthread-cpus" in ' '.join(backend.mpi_cmd)
+                with pytest.raises(
+                        RuntimeError,
+                        match="MPI simulation failed. Return code: 1"):
+                    simulate_dipole(net, tstop=40)
+
+            expected_string = ('Received BrokenPipeError exception. '
+                               'Child process failed unexpectedly')
+            assert len(record) == 2
+            assert expected_string in record[0].message.args[0]
+
+        # Check that simulation succeeds if oversubscription is activated but
+        # unnecessary
+        with MPIBackend(
+                n_procs=2,
+                hwthreading=hwthreading_enabled,
+                oversubscribe=True) as backend:
+            assert "--oversubscribe" in ' '.join(backend.mpi_cmd)
+            if detected_hwthreading:
+                assert "--use-hwthread-cpus" in ' '.join(backend.mpi_cmd)
             simulate_dipole(net, tstop=40)
 
     @pytest.mark.parametrize("backend", ['mpi', 'joblib'])


### PR DESCRIPTION
This takes George's old GUI-specific `_available_cores()` method, moves it, and greatly expands it to include updates to the logic about cores and hardware-threading which was previously inside `MPIBackend.__init__()`. This was necessary due to the number of common but different outcomes based on platform, architecture, hardware-threading support, and user choice. These changes do not involve very many lines of code, but a good amount of thought and testing has gone into them. Importantly, these `MPIBackend` API changes are backwards-compatible, and no changes to current usage code are needed. I suggest you read the long comments in
`parallel_backends.py::_determine_cores_hwthreading()` outlining how each variation is handled.

Previously, if the user did not provide the number of MPI Processes they wanted to use, `MPIBackend` assumed that the number of detected "logical" cores would suffice. As George previously showed, this does not work for HPC environments like on OSCAR, where the only true number of cores that we are allowed to use is found by
`psutil.Process().cpu_affinity()`, the "affinity" core number. There is a third type of number of cores besides "logical" and "affinity" which is important: "physical". However, there was an additional problem here that was still unaddressed: hardware-threading. Different platforms and situations report different numbers of logical, affinity, and physical CPU cores. One of the factors that affects this is if there is hardware-threading present on the machine, such as Intel Hyperthreading. In the case of an example Linux laptop having an Intel chip with Hyperthreading, the logical and physical core numbers will report different values with respect to each other: logical includes Hyperthreads
(e.g. `psutil.cpu_count(logical=True)` reports 8 cores), but physical does not
(e.g. `psutil.cpu_count(logical=False)` reports 4 cores). If we tell MPI to use 8 cores ("logical"), then we ALSO need to tell it to also enable the hardware-threading option. However, if the user does not want to enable hardware-threading, then we need to make this an option, tell MPI to use 4 cores
("physical"), and tell MPI to not use the hardware-threading option. The "affinity" core number makes things even more complicated, since in the Linux laptop example, it is equal to the logical core number. However, on OSCAR, it is very different than the logical core number, and on Macos, it is not present at all.

In `_determine_cores_hwthreading()`, if you read the lengthy comments, I have thought through each common scenario, and I believe resolved what to do for each, with respect to the number of cores to use and whether or not to use hardware-threading. These scenarios include: the user choosing to use hardware-threading (default) or not, across Macos variations with and without hardware-threading, Linux local computer variations with and without hardware-threading, and Linux HPC (e.g. OSCAR) variations which appear to never support hardware-threading. In the Windows case, due to both #589 and the currently-untested MPI integration on Windows, I always report the machine as not having hardware-threading.

Additionally, previously, if the user did provide a number for MPI Processes, `MPIBackend` used some "heuristics" to decide whether to use MPI oversubscription and/or hardware-threading, but the user could not override these heuristics. Now, when a user instantiates an `MPIBackend` with `__init__()` and uses the defaults, hardware-threading is detected more robustly and enabled by default, and oversubscription is enabled based on its own heuristics; this is the case when the new arguments `hwthreading` and `oversubscribe` are set to their default value of `None`. However, if the user knows what they're doing, they can also pass either `True` or `False` to either of these options to force them on or off. Furthermore, in the case of `hwthreading`, if the user indicates they do not want to use it, then
`_determine_cores_hwthreading()` correctly returns the number of NON-hardware-threaded cores for MPI's use, instead of the core number including hardware-threads.

I have also modified and expanded the appropriate testing to compensate for these changes.

Note that this does NOT change the default number of jobs to use for the GUI if MPI is detected. Such a change breaks the current `test_gui.py` testing: see #960
https://github.com/jonescompneurolab/hnn-core/issues/960