### PR TITLE
[MAINT] Decouple `_VizManager` from `HNNGUI`'s target-data widget

### DIFF
--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install ruff for use before ANY other tests
         shell: bash -el {0}
         run: |
-          pip install --verbose ruff
+          pip install --verbose "ruff<0.16.0"
 
       - name: Check ruff formatting
         shell: bash -el {0}

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install ruff for use before ANY other tests
         shell: cmd
         run: |
-          pip install --verbose ruff
+          pip install --verbose "ruff<0.16.0"
 
       - name: Check ruff formatting
         shell: cmd

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -1203,9 +1203,6 @@ class _VizManager:
             template_name = list(fig_templates.keys())[0]
         self._simulate_switch_fig_template(template_name)
 
-        # Update the external data widget (widget_opt_target_data)
-        # self.update_external_data_widget()
-
     def build_visualization_window(self):
         """build visualization-window (to occupy AppLayout's right_sidebar)"""
         with self.axes_config_output:
@@ -1250,38 +1247,6 @@ class _VizManager:
         ).add_class("visualization-tab-contents")
 
         return visualization_tab
-
-    ## Update gui.opt_target_widgets["target_dipole_data"]
-    def update_external_data_widget(self):
-        """Enable exfiltration of simulation data by `HNNGUI` objects.
-
-        This allows external registered widgets (such as `HNNGUI.opt_target_widgets`),
-        which are "external" to `_VizManager`, to access `_VizManager`'s available
-        simulation data entries.
-
-        Note: this relies on the assumption that `HNNGUI` has externally added the
-        attribute `_external_data_widget` to `_VizManager`, which it does inside
-        `HNNGUI.update_opt_tab_target_widgets()` which is always called at the time of
-        `HNNGUI.compose()` (see here:
-        https://github.com/asoplata/hnn-core/blob/4c52a1aeed522ee1071d1acef13e29254d5447c0/hnn_core/gui/gui.py#L2329
-        ). Initializing `_VizManager` is NOT enough to create this attribute.
-        """
-        if hasattr(self, "_external_data_widget") and isinstance(
-            self._external_data_widget, Dropdown
-        ):
-            all_sim_names = data_store.all_data_names or [" "]
-
-            ## self._external_data_widget = gui.opt_target_widgets["target_dipole_data"]
-            prior_value = self._external_data_widget.value
-
-            # Note updating the options of the widget resets the value
-            # _external_data_widget is a DropDown
-            self._external_data_widget.options = all_sim_names
-            self._external_data_widget.value = prior_value
-        else:
-            logger.warning(
-                "No external data widget found for visualization manager to update."
-            )
 
     def _layout_template_change(self, template_type):
         # check if plot set type requires loaded sim-data

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -1204,7 +1204,7 @@ class _VizManager:
         self._simulate_switch_fig_template(template_name)
 
         # Update the external data widget (widget_opt_target_data)
-        self.update_external_data_widget()
+        # self.update_external_data_widget()
 
     def build_visualization_window(self):
         """build visualization-window (to occupy AppLayout's right_sidebar)"""
@@ -1251,6 +1251,7 @@ class _VizManager:
 
         return visualization_tab
 
+    ## Update gui.opt_target_widgets["target_dipole_data"]
     def update_external_data_widget(self):
         """Enable exfiltration of simulation data by `HNNGUI` objects.
 
@@ -1270,7 +1271,9 @@ class _VizManager:
         ):
             all_sim_names = data_store.all_data_names or [" "]
 
+            ## self._external_data_widget = gui.opt_target_widgets["target_dipole_data"]
             prior_value = self._external_data_widget.value
+
             # Note updating the options of the widget resets the value
             # _external_data_widget is a DropDown
             self._external_data_widget.options = all_sim_names

--- a/hnn_core/gui/_viz_manager.py
+++ b/hnn_core/gui/_viz_manager.py
@@ -1430,8 +1430,3 @@ class _VizManager:
                 buttons.children[1].click()
         except Exception:
             raise
-
-
-def _is_simulation(data):
-    """Determines if saved data is a simulation."""
-    return data["net"] is not None

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -1329,8 +1329,12 @@ class HNNGUI:
             )
 
         def _on_upload_data(change):
-            return on_upload_data_change(change, self.viz_manager, self._log_out, 
-                                         self.opt_target_widgets["target_dipole_data"])
+            return on_upload_data_change(
+                change,
+                self.viz_manager,
+                self._log_out,
+                self.opt_target_widgets["target_dipole_data"],
+            )
 
         def _run_button_clicked(b):
             return run_button_clicked(

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -4690,8 +4690,8 @@ def on_upload_data_change(change, viz_manager, log_out, target_dipole_data_widge
         _template_name = "[Blank] single figure"
 
         # there is no pointer to gui on this function.
-        # so we cant update the gui.opt_target_widgets["target_dipole_data"]
-        # widget diectly using HNNGUI.
+        # so we can't update the gui.opt_target_widgets["target_dipole_data"]
+        # widget directly using HNNGUI.
         # I assume the workaround was done using _viz_manager
         viz_manager.reset_fig_config_tabs(template_name=_template_name)
         _update_target_dipole_data_widget(target_dipole_data_widget)

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -1281,7 +1281,7 @@ class HNNGUI:
     def _link_callbacks(self):
         """Link callbacks to UI components."""
 
-        def _handle_backend_change(backend_type):
+        def _handle_backend_change_cb(backend_type):
             return handle_backend_change(
                 backend_type.new,
                 self._backend_config_out,
@@ -1289,7 +1289,7 @@ class HNNGUI:
                 self.widget_n_jobs,
             )
 
-        def _add_drive_button_clicked(b):
+        def _add_drive_button_clicked_cb(b):
             location = self.widget_location_selection.value.lower()
             output = self.add_drive_tab_drive_widget(
                 self.widget_drive_type_selection.value,
@@ -1303,7 +1303,7 @@ class HNNGUI:
             )
             return output
 
-        def _delete_drives_clicked(b):
+        def _delete_drives_clicked_cb(b):
             self._drives_out.clear_output()
             self._opt_drives_out.clear_output()
             # black magic: the following does not work
@@ -1317,26 +1317,35 @@ class HNNGUI:
             while len(self.opt_drive_boxes) > 0:
                 self.opt_drive_boxes.pop()
 
-        def _on_upload_connectivity(change):
+        def _on_upload_connectivity_cb(change):
             new_params = self.on_upload_params_change(
                 change, self.layout["drive_textbox"], load_type="connectivity"
             )
             self.params = new_params
 
-        def _on_upload_drives(change):
+        def _on_upload_drives_cb(change):
             _ = self.on_upload_params_change(
                 change, self.layout["drive_textbox"], load_type="drives"
             )
 
-        def _on_upload_data(change):
-            return on_upload_data_change(
-                change,
-                self.viz_manager,
-                self._log_out,
-                self.opt_target_widgets["target_dipole_data"],
-            )
+        def _on_upload_data_cb(change):
+            ## this function should get data and  take care of the state of the widgets
+            # Check state of the widget
+            if not change["owner"].value:
+                return
+            try:
+                self._on_upload_data(file_path=change["new"][0])
+            except Exception:
+                self._simulation_status_bar.value = self._simulation_status_contents[
+                    "failed"
+                ]
+                logger.error(traceback.format_exc())
+                return
+            finally:
+                # Reset the load file widget
+                change["owner"].value = []
 
-        def _run_button_clicked(b):
+        def _run_button_clicked_cb(b):
             return run_button_clicked(
                 self.widget_simulation_name,
                 self._log_out,
@@ -1363,7 +1372,7 @@ class HNNGUI:
                 self.opt_target_widgets["target_dipole_data"],
             )
 
-        def _run_opt_button_clicked(b):
+        def _run_opt_button_clicked_cb(b):
             result = run_opt_button_clicked(
                 self.widget_simulation_name,
                 self._log_out,
@@ -1407,7 +1416,7 @@ class HNNGUI:
                 self._update_opt_history_button()
             return
 
-        def _simulation_list_change(value):
+        def _simulation_list_change_cb(value):
             # Simulation Data
             _simulation_data, file_extension = _serialize_simulation(
                 self._log_out, data_store.simulated_data, self.simulation_list_widget
@@ -1455,12 +1464,12 @@ class HNNGUI:
                 mimetype="application/json",
             )
 
-        def _driver_type_change(value):
+        def _driver_type_change_cb(value):
             self.widget_location_selection.disabled = (
                 True if value.new == "Tonic" else False
             )
 
-        def _cell_type_radio_change(value):
+        def _cell_type_radio_change_cb(value):
             _update_cell_params_vbox(
                 self._cell_params_out,
                 self.cell_parameters_widgets,
@@ -1468,7 +1477,7 @@ class HNNGUI:
                 self.cell_layer_radio_buttons.value,
             )
 
-        def _cell_layer_radio_change(value):
+        def _cell_layer_radio_change_cb(value):
             _update_cell_params_vbox(
                 self._cell_params_out,
                 self.cell_parameters_widgets,
@@ -1476,31 +1485,31 @@ class HNNGUI:
                 value.new,
             )
 
-        def _opt_obj_fun_change(value):
+        def _opt_obj_fun_change_cb(value):
             self._update_opt_target_hbox(value.new)
 
-        def _opt_solver_change(value):
+        def _opt_solver_change_cb(value):
             self._update_opt_solver_hbox(value.new)
 
-        self.widget_backend_selection.observe(_handle_backend_change, "value")
-        self.add_drive_button.on_click(_add_drive_button_clicked)
-        self.delete_drive_button.on_click(_delete_drives_clicked)
-        self.load_connectivity_button.observe(_on_upload_connectivity, names="value")
-        self.load_drives_button.observe(_on_upload_drives, names="value")
-        self.run_button.on_click(_run_button_clicked)
-        self.run_opt_button.on_click(_run_opt_button_clicked)
+        self.widget_backend_selection.observe(_handle_backend_change_cb, "value")
+        self.add_drive_button.on_click(_add_drive_button_clicked_cb)
+        self.delete_drive_button.on_click(_delete_drives_clicked_cb)
+        self.load_connectivity_button.observe(_on_upload_connectivity_cb, names="value")
+        self.load_drives_button.observe(_on_upload_drives_cb, names="value")
+        self.run_button.on_click(_run_button_clicked_cb)
+        self.run_opt_button.on_click(_run_opt_button_clicked_cb)
 
-        self.load_data_button.observe(_on_upload_data, names="value")
-        self.simulation_list_widget.observe(_simulation_list_change, "value")
-        self.widget_drive_type_selection.observe(_driver_type_change, "value")
+        self.load_data_button.observe(_on_upload_data_cb, names="value")
+        self.simulation_list_widget.observe(_simulation_list_change_cb, "value")
+        self.widget_drive_type_selection.observe(_driver_type_change_cb, "value")
 
-        self.cell_type_radio_buttons.observe(_cell_type_radio_change, "value")
-        self.cell_layer_radio_buttons.observe(_cell_layer_radio_change, "value")
+        self.cell_type_radio_buttons.observe(_cell_type_radio_change_cb, "value")
+        self.cell_layer_radio_buttons.observe(_cell_layer_radio_change_cb, "value")
 
         # Many Optimization tab observations, including dual-linking widgets with their
         # equivalent in the Run tab:
-        self.widget_opt_obj_fun.observe(_opt_obj_fun_change, "value")
-        self.widget_opt_solver.observe(_opt_solver_change, "value")
+        self.widget_opt_obj_fun.observe(_opt_obj_fun_change_cb, "value")
+        self.widget_opt_solver.observe(_opt_solver_change_cb, "value")
 
         link(
             (self.widget_opt_tstop, "value"),
@@ -1522,6 +1531,54 @@ class HNNGUI:
             (self.widget_default_scaling, "value"),
             (self.widget_opt_scaling, "value"),
         )
+
+    def _on_upload_data(self, file_path):
+        # Parsing path into filename and extension
+        data_dict = file_path
+        dict_name = data_dict["name"].rsplit(".", 1)
+        data_filename = dict_name[0]
+        file_extension = f".{dict_name[1]}"
+
+        # If data was already loaded return
+        if data_store.loaded_data.get(data_filename) is not None:
+            with self._log_out:
+                logger.error(f"Found existing data: {data_filename}.")
+            return
+
+        # Read the file
+        ext_content = data_dict["content"]
+        ext_content = codecs.decode(ext_content, encoding="utf-8")
+        with self._log_out:
+            # Write loaded data to data object
+            data_store.loaded_data[data_filename] = {
+                "net": None,
+                "dpls": [_read_dipole_txt(io.StringIO(ext_content), file_extension)],
+            }
+            logger.info(f"External data {data_filename} loaded.")
+
+            # Create a dipole plot
+            _template_name = "[Blank] single figure"
+
+            # there is no pointer to gui on this function.
+            # so we can't update the gui.opt_target_widgets["target_dipole_data"]
+            # widget directly using HNNGUI.
+            # I assume the workaround was done using _viz_manager
+            self.viz_manager.reset_fig_config_tabs(template_name=_template_name)
+            _update_target_dipole_data_widget(
+                self.opt_target_widgets["target_dipole_data"]
+            )
+
+            self.viz_manager.add_figure()
+            fig_name = _idx2figname(self.viz_manager.data["fig_idx"]["idx"] - 1)
+            process_configs = {"dipole_smooth": 0, "dipole_scaling": 1}
+            self.viz_manager._simulate_edit_figure(
+                fig_name,
+                ax_name="ax0",
+                simulation_name=data_filename,
+                plot_type="current dipole",
+                preprocessing_config=process_configs,
+                operation="plot",
+            )
 
     def _delete_single_drive(self, b):
         index = self.drive_accordion.selected_index
@@ -4657,58 +4714,6 @@ def _update_target_dipole_data_widget(target_dipole_data_widget):
     prior_value = target_dipole_data_widget.value
     target_dipole_data_widget.options = all_sim_names
     target_dipole_data_widget.value = prior_value
-
-
-def on_upload_data_change(change, viz_manager, log_out, target_dipole_data_widget):
-    if len(change["owner"].value) == 0:
-        return
-    # Parsing file information from the 'change' object passed in from
-    # the upload file widget.
-    data_dict = change["new"][0]
-    dict_name = data_dict["name"].rsplit(".", 1)
-    data_filename = dict_name[0]
-    file_extension = f".{dict_name[1]}"
-
-    # If data was already loaded return
-    if data_store.loaded_data.get(data_filename) is not None:
-        with log_out:
-            logger.error(f"Found existing data: {data_filename}.")
-        return
-
-    # Read the file
-    ext_content = data_dict["content"]
-    ext_content = codecs.decode(ext_content, encoding="utf-8")
-    with log_out:
-        # Write loaded data to data object
-        data_store.loaded_data[data_filename] = {
-            "net": None,
-            "dpls": [_read_dipole_txt(io.StringIO(ext_content), file_extension)],
-        }
-        logger.info(f"External data {data_filename} loaded.")
-
-        # Create a dipole plot
-        _template_name = "[Blank] single figure"
-
-        # there is no pointer to gui on this function.
-        # so we can't update the gui.opt_target_widgets["target_dipole_data"]
-        # widget directly using HNNGUI.
-        # I assume the workaround was done using _viz_manager
-        viz_manager.reset_fig_config_tabs(template_name=_template_name)
-        _update_target_dipole_data_widget(target_dipole_data_widget)
-
-        viz_manager.add_figure()
-        fig_name = _idx2figname(viz_manager.data["fig_idx"]["idx"] - 1)
-        process_configs = {"dipole_smooth": 0, "dipole_scaling": 1}
-        viz_manager._simulate_edit_figure(
-            fig_name,
-            ax_name="ax0",
-            simulation_name=data_filename,
-            plot_type="current dipole",
-            preprocessing_config=process_configs,
-            operation="plot",
-        )
-        # Reset the load file widget
-        change["owner"].value = []
 
 
 def _drive_widget_to_dict(drive, name):

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -1564,9 +1564,7 @@ class HNNGUI:
             # widget directly using HNNGUI.
             # I assume the workaround was done using _viz_manager
             self.viz_manager.reset_fig_config_tabs(template_name=_template_name)
-            _update_target_dipole_data_widget(
-                self.opt_target_widgets["target_dipole_data"]
-            )
+            self._update_target_dipole_data_widget()
 
             self.viz_manager.add_figure()
             fig_name = _idx2figname(self.viz_manager.data["fig_idx"]["idx"] - 1)
@@ -1579,6 +1577,13 @@ class HNNGUI:
                 preprocessing_config=process_configs,
                 operation="plot",
             )
+
+    def _update_target_dipole_data_widget(self):
+        """refresh gui.opt_target_widgets["target_dipole_data"] dropdown using data_store"""
+        all_loaded_data_names = list(data_store.loaded_data) or [" "]
+        prior_value = self.opt_target_widgets["target_dipole_data"].value
+        self.opt_target_widgets["target_dipole_data"].options = all_loaded_data_names
+        self.opt_target_widgets["target_dipole_data"].value = prior_value
 
     def _delete_single_drive(self, b):
         index = self.drive_accordion.selected_index
@@ -4708,14 +4713,6 @@ def get_cell_param_default_value(cell_type_key, param_dict):
     return param_dict[cell_type_key]
 
 
-def _update_target_dipole_data_widget(target_dipole_data_widget):
-    """refresh gui.opt_target_widgets["target_dipole_data"] dropdown using data_store"""
-    all_sim_names = list(data_store.all_data_names) or [" "]
-    prior_value = target_dipole_data_widget.value
-    target_dipole_data_widget.options = all_sim_names
-    target_dipole_data_widget.value = prior_value
-
-
 def _drive_widget_to_dict(drive, name):
     """Creates a dict of input widget values
 
@@ -4995,7 +4992,6 @@ def run_button_clicked(
                 simulations_list_widget.value = sim_names[0]
 
             viz_manager.reset_fig_config_tabs()
-            _update_target_dipole_data_widget(target_dipole_data_widget)
 
             # update default visualization params in gui based on widget
             fig_default_params["default_smoothing"] = widget_default_smoothing.value
@@ -6268,7 +6264,6 @@ def run_opt_button_clicked(
             # The remainder of this function is just repeating some post-run
             # visualization steps, which are identical to those in `run_button_clicked`
             viz_manager.reset_fig_config_tabs()
-            _update_target_dipole_data_widget(target_dipole_data_widget)
 
             # update default visualization params in gui based on widget
             fig_default_params["default_smoothing"] = opt_smoothing

--- a/hnn_core/gui/gui.py
+++ b/hnn_core/gui/gui.py
@@ -1329,7 +1329,8 @@ class HNNGUI:
             )
 
         def _on_upload_data(change):
-            return on_upload_data_change(change, self.viz_manager, self._log_out)
+            return on_upload_data_change(change, self.viz_manager, self._log_out, 
+                                         self.opt_target_widgets["target_dipole_data"])
 
         def _run_button_clicked(b):
             return run_button_clicked(
@@ -1355,6 +1356,7 @@ class HNNGUI:
                 self.simulation_list_widget,
                 self.cell_parameters_widgets,
                 self.global_gain_widgets,
+                self.opt_target_widgets["target_dipole_data"],
             )
 
         def _run_opt_button_clicked(b):
@@ -1386,6 +1388,7 @@ class HNNGUI:
                 self.widget_opt_scaling.value,
                 self.opt_target_widgets,
                 self.opt_solver_widgets,
+                self.opt_target_widgets["target_dipole_data"],
             )
             # Re-load our NEW, optimized drive parameters after an optimization run:
             if result:
@@ -2372,9 +2375,9 @@ class HNNGUI:
         #
         # Note: this is what first creates the `VizManager` object's
         # `_external_data_widget` attribute!
-        self.viz_manager._external_data_widget = self.opt_target_widgets[
-            "target_dipole_data"
-        ]
+        # self.viz_manager._external_data_widget = self.opt_target_widgets[
+        #     "target_dipole_data"
+        # ]
 
         self.opt_target_widgets["n_trials"] = BoundedIntText(
             value=prior_target_state.get("n_trials", 1),
@@ -4644,7 +4647,15 @@ def get_cell_param_default_value(cell_type_key, param_dict):
     return param_dict[cell_type_key]
 
 
-def on_upload_data_change(change, viz_manager, log_out):
+def _update_target_dipole_data_widget(target_dipole_data_widget):
+    """refresh gui.opt_target_widgets["target_dipole_data"] dropdown using data_store"""
+    all_sim_names = list(data_store.all_data_names) or [" "]
+    prior_value = target_dipole_data_widget.value
+    target_dipole_data_widget.options = all_sim_names
+    target_dipole_data_widget.value = prior_value
+
+
+def on_upload_data_change(change, viz_manager, log_out, target_dipole_data_widget):
     if len(change["owner"].value) == 0:
         return
     # Parsing file information from the 'change' object passed in from
@@ -4673,7 +4684,14 @@ def on_upload_data_change(change, viz_manager, log_out):
 
         # Create a dipole plot
         _template_name = "[Blank] single figure"
+
+        # there is no pointer to gui on this function.
+        # so we cant update the gui.opt_target_widgets["target_dipole_data"]
+        # widget diectly using HNNGUI.
+        # I assume the workaround was done using _viz_manager
         viz_manager.reset_fig_config_tabs(template_name=_template_name)
+        _update_target_dipole_data_widget(target_dipole_data_widget)
+
         viz_manager.add_figure()
         fig_name = _idx2figname(viz_manager.data["fig_idx"]["idx"] - 1)
         process_configs = {"dipole_smooth": 0, "dipole_scaling": 1}
@@ -4893,6 +4911,7 @@ def run_button_clicked(
     simulations_list_widget,
     cell_parameters_widgets,
     global_gain_textfields,
+    target_dipole_data_widget,
 ):
     """Run the simulation and plot outputs."""
     simulation_data = data_store.simulated_data
@@ -4967,6 +4986,7 @@ def run_button_clicked(
                 simulations_list_widget.value = sim_names[0]
 
             viz_manager.reset_fig_config_tabs()
+            _update_target_dipole_data_widget(target_dipole_data_widget)
 
             # update default visualization params in gui based on widget
             fig_default_params["default_smoothing"] = widget_default_smoothing.value
@@ -5858,6 +5878,7 @@ def run_opt_button_clicked(
     opt_scaling,
     opt_target_widgets,
     opt_solver_widgets,
+    target_dipole_data_widget,
 ):
     """Run an Optimization, then re-run its final simulation and plot its outputs.
 
@@ -6238,6 +6259,7 @@ def run_opt_button_clicked(
             # The remainder of this function is just repeating some post-run
             # visualization steps, which are identical to those in `run_button_clicked`
             viz_manager.reset_fig_config_tabs()
+            _update_target_dipole_data_widget(target_dipole_data_widget)
 
             # update default visualization params in gui based on widget
             fig_default_params["default_smoothing"] = opt_smoothing

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -468,10 +468,12 @@ def test_gui_upload_data():
 
     # No data loading for legacy multi-trial data files.
     file3_url = "https://raw.githubusercontent.com/jonescompneurolab/hnn/master/data/gamma_tutorial/100_trials.txt"  # noqa
-    with pytest.raises(
-        ValueError, match="Data are supposed to have 2 or 4 columns while we have 101."
-    ):
-        gui._simulate_upload_data(file3_url)
+    gui._simulate_upload_data(file3_url)
+    assert any(
+        "Data are supposed to have 2 or 4 columns while we have 101." in entry["text"]
+        for entry in gui._log_out.outputs
+    )
+
     assert len(data_store.loaded_data) == 2
     assert len(gui.viz_manager.data["figs"]) == 2
 

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -2299,17 +2299,12 @@ def test_data_store_reset_on_gui_reinit(setup_gui):
 
 def test_data_store_shared_singleton_across_modules(setup_gui):
     """gui.py and _viz_manager.py must observe the exact same data_store instance"""
-    ## This import is only nedeed in this scope
-    # import hnn_core.gui._viz_manager as _viz_manager
-
-    # assert _viz_manager.data_store is data_store
-
     gui = setup_gui
     sim_name = "shared_data_store_test"
     gui.widget_simulation_name.value = sim_name
     gui.run_button.click()
 
-    assert sim_name in gui.opt_target_widgets["target_dipole_data"].options
+    assert sim_name in gui.simulation_list_widget.options
     # data written through gui.py is immediately
     # visible to _VizManager's data_store widget updates
     gui.viz_manager.templates_dropdown.value = "Drive-Dipole (2x1)"

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -27,7 +27,6 @@ from hnn_core.gui._viz_manager import (
     _plot_types,
     _no_overlay_plot_types,
     unlink_relink,
-    data_templates,
 )
 from hnn_core.gui.gui import (
     _GUI_PrintToLogger,

--- a/hnn_core/tests/test_gui.py
+++ b/hnn_core/tests/test_gui.py
@@ -27,6 +27,7 @@ from hnn_core.gui._viz_manager import (
     _plot_types,
     _no_overlay_plot_types,
     unlink_relink,
+    data_templates,
 )
 from hnn_core.gui.gui import (
     _GUI_PrintToLogger,
@@ -2307,7 +2308,8 @@ def test_data_store_shared_singleton_across_modules(setup_gui):
     gui.widget_simulation_name.value = sim_name
     gui.run_button.click()
 
+    assert sim_name in gui.opt_target_widgets["target_dipole_data"].options
     # data written through gui.py is immediately
     # visible to _VizManager's data_store widget updates
-    gui.viz_manager.update_external_data_widget()
-    assert sim_name in gui.opt_target_widgets["target_dipole_data"].options
+    gui.viz_manager.templates_dropdown.value = "Drive-Dipole (2x1)"
+    assert sim_name in gui.viz_manager.datasets_dropdown.value

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,13 @@ if __name__ == "__main__":
     extras = {
         "opt": ["cma", "scikit-learn"],
         "parallel": ["joblib", "psutil"],
-        "test": ["codespell", "pytest", "pytest-cov", "pytest-xdist", "ruff"],
+        "test": [
+            "codespell",
+            "pytest",
+            "pytest-cov",
+            "pytest-xdist",
+            "ruff<0.16.0",
+        ],
         "docs": [
             "mne",
             "myst-parser",


### PR DESCRIPTION
### Changes On this PR
Removes a leaky, bidirectional coupling between `_VizManager` and `HNNGUI`, where
`_VizManager` was reaching into and mutating a widget (`opt_target_widgets["target_dipole_data"]`)
that it does not own.

- **`hnn_core/gui/_viz_manager.py`**: Removed the call to
  `self.update_external_data_widget()` from `reset_fig_config_tabs()`. The
  `update_external_data_widget()` method and its `_external_data_widget` attribute
  are no longer used by `_VizManager` and are slated for removal.
- **`hnn_core/gui/gui.py`**:
  - Added a small, self-contained helper `_update_target_dipole_data_widget(widget)`
    that refreshes a dropdown's options/value from `data_store.all_data_names`.
  - Removed the `viz_manager._external_data_widget = ...` injection from
    `update_opt_tab_target_widgets()`.
  - `on_upload_data_change`, `run_button_clicked`, and `run_opt_button_clicked` now
    take an explicit `target_dipole_data_widget` parameter and call
    `_update_target_dipole_data_widget(...)` directly, instead of relying on
    `_VizManager` to do it implicitly.
  - Updated the corresponding callback closures in `_link_callbacks()` to pass
    `self.opt_target_widgets["target_dipole_data"]` through to these functions.