### PR TITLE
[MRG] MAINT cap ruff version due to breaking changes (#1333)

### DIFF
--- a/.github/workflows/unix_unit_tests.yml
+++ b/.github/workflows/unix_unit_tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install ruff for use before ANY other tests
         shell: bash -el {0}
         run: |
-          pip install --verbose ruff
+          pip install --verbose "ruff<0.16.0"
 
       - name: Check ruff formatting
         shell: bash -el {0}

--- a/.github/workflows/windows_unit_tests.yml
+++ b/.github/workflows/windows_unit_tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install ruff for use before ANY other tests
         shell: cmd
         run: |
-          pip install --verbose ruff
+          pip install --verbose "ruff<0.16.0"
 
       - name: Check ruff formatting
         shell: cmd

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,13 @@ if __name__ == "__main__":
     extras = {
         "opt": ["cma", "scikit-learn"],
         "parallel": ["joblib", "psutil"],
-        "test": ["codespell", "pytest", "pytest-cov", "pytest-xdist", "ruff"],
+        "test": [
+            "codespell",
+            "pytest",
+            "pytest-cov",
+            "pytest-xdist",
+            "ruff<0.16.0",
+        ],
         "docs": [
             "mne",
             "myst-parser",


### PR DESCRIPTION
This is a patch intended to apply https://github.com/jonescompneurolab/hnn-core/pull/1333 to Camilo's feature branch, which will enable his secondary PRs to also not suffer from the problem

* MAINT cap ruff version due to breaking changes

* FIX forgot to update standalone ruff install